### PR TITLE
Add allocators to resource classes as parent classes

### DIFF
--- a/src/resource/IResource.h
+++ b/src/resource/IResource.h
@@ -2,10 +2,6 @@
 #include <concepts>
 // TODO: implement some actual ownership of the Id through smart pointers with custom deallocators 
 //  maybe have like a templated IResource<std::unique_ptr<GLuint, glDeallocator<Derived>>> with CRTP in Derived classes
-// TODO: could be interesting to try to separate the concerns of allocation by adding an intermediate Allocator class
-//  that implements noexcept acquire/release methods and noexcept constructors/destructors,
-//  so that whenever the derived class throws, deallocation happens automatically.
-//  For example, the inheritance would look like: IResource <- ShaderAllocator <- Shader.
 
 
 // Base class for OpenGL resources that carry a handle (Shaders, Textures, VBOs, etc.). RAII-enabled.

--- a/src/resource/Shader.h
+++ b/src/resource/Shader.h
@@ -17,7 +17,8 @@ protected:
 	explicit ShaderAllocator(GLenum type) noexcept {
 		id_ = glCreateShader(type);
 #ifndef NDEBUG
-		std::cerr << "\nShaderAllocator("
+		std::cerr << "\n[id: " << id_ << "] "
+		          << "ShaderAllocator("
 		          << ((type == GL_FRAGMENT_SHADER) ? "GL_FRAGMENT_SHADER" : "")
 		          << ((type == GL_VERTEX_SHADER) ? "GL_VERTEX_SHADER" : "") << ")";
 #endif
@@ -25,7 +26,7 @@ protected:
 public:
 	virtual ~ShaderAllocator() override {
 #ifndef NDEBUG
-		std::cerr << "\n~ShaderAllocator()";
+		std::cerr << "\n[id: " << id_ << "] " << "~ShaderAllocator()" ;
 #endif
 		glDeleteShader(id_);
 	}
@@ -83,6 +84,9 @@ inline Shader::Shader(GLenum type, std::string filename) : ShaderAllocator(type)
 	// compile from file
 	try {
 		compile();
+#ifndef NDEBUG
+		std::cerr << getCompileInfo();
+#endif
 	}
 	catch (const std::runtime_error& e) {
 		std::cerr << e.what();

--- a/src/resource/Shader.h
+++ b/src/resource/Shader.h
@@ -32,28 +32,23 @@ public:
 };
 
 
-class Shader : public IResource {
+class Shader : public ShaderAllocator {
 private:
 	std::string filename_;
 	GLenum type_;
 
-	void acquireResource() noexcept { id_ = glCreateShader(type_); }
-	void releaseResource() noexcept { glDeleteShader(id_); }
+	void compile() const;
 
 public:
 	Shader(GLenum type, std::string filename);
 
-	virtual ~Shader() override { releaseResource(); }
-
 	GLenum getType() const noexcept { return type_; }
 	const std::string& getFilename() const noexcept { return filename_; }
+
+	std::string getCompileInfo() const;
 	std::string getSource() const { return getShaderFileSource(filename_); }
 
 	static std::string getShaderFileSource(const std::string& filename);
-
-	std::string getCompileInfo() const;
-
-	void compile() const;
 };
 
 
@@ -75,24 +70,22 @@ public:
 
 
 
-inline Shader::Shader(GLenum type, std::string filename) :
-		type_{ type }, filename_{ std::move(filename) } {
+inline Shader::Shader(GLenum type, std::string filename) : ShaderAllocator(type) {
+	type_ = type;
+	filename_ = std::move(filename);
 
 	// check shader type to be a valid enum
+	// TODO: hopefully one day this will be a compile time error
 	if ( (type_ != GL_VERTEX_SHADER) && (type_ != GL_FRAGMENT_SHADER) ) {
 		throw std::invalid_argument("invalid_argument: invalid shader type");
 	}
 
-	// create shader id and compile from file
-	acquireResource();
-	try { compile(); }
+	// compile from file
+	try {
+		compile();
+	}
 	catch (const std::runtime_error& e) {
 		std::cerr << e.what();
-		releaseResource();
-		throw;
-	}
-	catch (...) {
-		releaseResource();
 		throw;
 	}
 

--- a/src/resource/Shader.h
+++ b/src/resource/Shader.h
@@ -12,6 +12,26 @@
 #include "IResource.h"
 
 
+class ShaderAllocator : public IResource {
+protected:
+	explicit ShaderAllocator(GLenum type) noexcept {
+		id_ = glCreateShader(type);
+#ifndef NDEBUG
+		std::cerr << "\nShaderAllocator("
+		          << ((type == GL_FRAGMENT_SHADER) ? "GL_FRAGMENT_SHADER" : "")
+		          << ((type == GL_VERTEX_SHADER) ? "GL_VERTEX_SHADER" : "") << ")";
+#endif
+	}
+public:
+	virtual ~ShaderAllocator() override {
+#ifndef NDEBUG
+		std::cerr << "\n~ShaderAllocator()";
+#endif
+		glDeleteShader(id_);
+	}
+};
+
+
 class Shader : public IResource {
 private:
 	std::string filename_;

--- a/src/resource/ShaderProgram.h
+++ b/src/resource/ShaderProgram.h
@@ -13,10 +13,21 @@
 
 class ShaderProgramAllocator : public IResource {
 protected:
-	ShaderProgramAllocator() noexcept { id_ = glCreateProgram(); }
+	ShaderProgramAllocator() noexcept {
+		id_ = glCreateProgram();
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] "
+		          << "ShaderProgramAllocator()";
+#endif
+	}
 
 public:
-	virtual ~ShaderProgramAllocator() override { glDeleteProgram(id_); }
+	virtual ~ShaderProgramAllocator() override {
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] " << "~ShaderProgramAllocator()" ;
+#endif
+		glDeleteProgram(id_);
+	}
 };
 
 
@@ -27,6 +38,9 @@ private:
 public:
 	explicit ShaderProgram(std::vector<refw<Shader>> shaders) : shaders_{ std::move(shaders) } {
 		link();
+#ifndef NDEBUG
+		std::cerr << getLinkInfo();
+#endif
 	}
 
 	void link() const;
@@ -133,7 +147,7 @@ inline std::string ShaderProgram::getLinkInfo() const {
 	std::string output{};
 	GLint success = getLinkSuccess();
 	output += "\nLinking Status: " + ((success == GL_TRUE) ? std::string("Success") : std::string("Failure"));
-	output += "\nProgram Id: " + std::to_string(id_);
+	output += "\nProgram Id: " + std::to_string(id_) + "\n";
 
 	return output;
 }

--- a/src/resource/ShaderProgram.h
+++ b/src/resource/ShaderProgram.h
@@ -5,10 +5,19 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-
 #include "TypeAliases.h"
 #include "IResource.h"
 #include "Shader.h"
+
+
+class ShaderProgramAllocator : public IResource {
+protected:
+	ShaderProgramAllocator() noexcept { id_ = glCreateProgram(); }
+
+public:
+	virtual ~ShaderProgramAllocator() override { glDeleteProgram(id_); }
+};
+
 
 class ShaderProgram : public IResource {
 private:

--- a/src/resource/Texture.h
+++ b/src/resource/Texture.h
@@ -16,35 +16,31 @@ public:
 };
 
 
-class Texture : public IResource {
+class Texture : public TextureAllocator {
 private:
 	std::string filename_;
 	const static std::array<GLenum, 32> texUnits_s;
 
-	void acquireResource() noexcept { glGenTextures(1, &id_); }
-	void releaseResource() noexcept { glDeleteTextures(1, &id_); }
-
 public:
 	Texture(const std::string& filename, GLenum format, GLint internalFormat = GL_RGB);
 
-	virtual ~Texture() override { releaseResource(); }
-
-	const std::string& getFilename() const { return filename_; }
 	void bind() { glBindTexture(GL_TEXTURE_2D, id_); }
-	
+
 	static void setActiveUnit(int texUnit) { glActiveTexture(texUnits_s.at(texUnit)); }
-	
+
 	// set Active Texture Unit and then bind the Texture to it
 	void setActiveUnitAndBind(int texUnit) {
 		setActiveUnit(texUnit);
 		bind();
 	}
 
+	const std::string& getFilename() const { return filename_; }
+
 
 };
 
 
-const std::array<GLenum, 32> Texture::texUnits_s{
+inline const std::array<GLenum, 32> Texture::texUnits_s{
 	GL_TEXTURE0,  GL_TEXTURE1,  GL_TEXTURE2,  GL_TEXTURE3,  GL_TEXTURE4,
 	GL_TEXTURE5,  GL_TEXTURE6,  GL_TEXTURE7,  GL_TEXTURE8,  GL_TEXTURE9,
 	GL_TEXTURE10, GL_TEXTURE11, GL_TEXTURE12, GL_TEXTURE13, GL_TEXTURE14,
@@ -68,9 +64,6 @@ inline Texture::Texture(const std::string& filename, GLenum format, GLint intern
 	if ( !data ) {
 		throw std::runtime_error("runtime_error: could not read image file " + texturePath);
 	}
-
-	acquireResource();
-
 
 	glBindTexture(GL_TEXTURE_2D, id_);
 	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, data);

--- a/src/resource/Texture.h
+++ b/src/resource/Texture.h
@@ -9,10 +9,21 @@
 
 class TextureAllocator : public IResource {
 protected:
-	TextureAllocator() noexcept { glGenTextures(1, &id_); }
+	TextureAllocator() noexcept {
+		glGenTextures(1, &id_);
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] "
+		          << "TextureAllocator()";
+#endif
+	}
 
 public:
-	virtual ~TextureAllocator() override { glDeleteTextures(1, &id_); }
+	virtual ~TextureAllocator() override {
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] " << "~TextureAllocator()" ;
+#endif
+		glDeleteTextures(1, &id_);
+	}
 };
 
 

--- a/src/resource/Texture.h
+++ b/src/resource/Texture.h
@@ -6,6 +6,16 @@
 #include "TypeAliases.h"
 #include "IResource.h"
 
+
+class TextureAllocator : public IResource {
+protected:
+	TextureAllocator() noexcept { glGenTextures(1, &id_); }
+
+public:
+	virtual ~TextureAllocator() override { glDeleteTextures(1, &id_); }
+};
+
+
 class Texture : public IResource {
 private:
 	std::string filename_;

--- a/src/resource/VAO.h
+++ b/src/resource/VAO.h
@@ -5,6 +5,16 @@
 #include "IResource.h"
 #include "VBO.h"
 
+
+class VAOAllocator : public IResource {
+protected:
+	VAOAllocator() noexcept { glGenVertexArrays(1, &id_); }
+
+public:
+	virtual ~VAOAllocator() override { glDeleteVertexArrays(1, &id_); }
+};
+
+
 class VAO : public IResource {
 private:
 	size_t numVertices_;

--- a/src/resource/VAO.h
+++ b/src/resource/VAO.h
@@ -8,10 +8,21 @@
 
 class VAOAllocator : public IResource {
 protected:
-	VAOAllocator() noexcept { glGenVertexArrays(1, &id_); }
+	VAOAllocator() noexcept {
+		glGenVertexArrays(1, &id_);
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] "
+		          << "VAOAllocator()";
+#endif
+	}
 
 public:
-	virtual ~VAOAllocator() override { glDeleteVertexArrays(1, &id_); }
+	virtual ~VAOAllocator() override {
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] " << "~VAOAllocator()" ;
+#endif
+		glDeleteVertexArrays(1, &id_);
+	}
 };
 
 

--- a/src/resource/VAO.h
+++ b/src/resource/VAO.h
@@ -15,18 +15,13 @@ public:
 };
 
 
-class VAO : public IResource {
+class VAO : public VAOAllocator {
 private:
 	size_t numVertices_;
-
-	void acquireResource() noexcept { glGenVertexArrays(1, &id_); }
-	void releaseResource() noexcept { glDeleteVertexArrays(1, &id_); }
 
 public:
 	// for now this only takes one VBO 
 	explicit VAO(const VBO& vbo, GLenum usage = GL_STATIC_DRAW);
-
-	virtual ~VAO() override { releaseResource(); }
 
 	void bind() const { glBindVertexArray(id_); }
 	static void unbind() { glBindVertexArray(0); }
@@ -46,7 +41,6 @@ public:
 
 inline VAO::VAO(const VBO& vbo, GLenum usage) {
 
-	acquireResource();
 	bind();
 
 	vbo.bind();

--- a/src/resource/VBO.h
+++ b/src/resource/VBO.h
@@ -18,10 +18,21 @@ struct VertexAttributeLayout {
 
 class VBOAllocator : public IResource {
 protected:
-	VBOAllocator() noexcept { glGenBuffers(1, &id_); }
+	VBOAllocator() noexcept {
+		glGenBuffers(1, &id_);
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] "
+		          << "VBOAllocator()";
+#endif
+	}
 
 public:
-	virtual ~VBOAllocator() override { glDeleteBuffers(1, &id_); }
+	virtual ~VBOAllocator() override {
+#ifndef NDEBUG
+		std::cerr << "\n[id: " << id_ << "] " << "~VBOAllocator()" ;
+#endif
+		glDeleteBuffers(1, &id_);
+	}
 };
 
 

--- a/src/resource/VBO.h
+++ b/src/resource/VBO.h
@@ -41,13 +41,13 @@ public:
 
 	const std::vector<float>& getData() const noexcept { return data_; }
 
-	const VertexAttributeLayout::AttribSize_t getStride() const;
+	VertexAttributeLayout::AttribSize_t getStride() const;
 
-	const VertexAttributeLayout::AttribSize_t getOffset(VertexAttributeLayout::AttribIndex_t index) const;
+	VertexAttributeLayout::AttribSize_t getOffset(VertexAttributeLayout::AttribIndex_t index) const;
 };
 
 
-inline const VertexAttributeLayout::AttribSize_t VBO::getStride() const {
+inline VertexAttributeLayout::AttribSize_t VBO::getStride() const {
 	VertexAttributeLayout::AttribSize_t sum{ 0 };
 	for ( const auto& currentLayout : attributeLayout_ ) {
 		sum += currentLayout.size;
@@ -56,7 +56,7 @@ inline const VertexAttributeLayout::AttribSize_t VBO::getStride() const {
 }
 
 
-inline const VertexAttributeLayout::AttribSize_t VBO::getOffset(VertexAttributeLayout::AttribIndex_t index) const {
+inline VertexAttributeLayout::AttribSize_t VBO::getOffset(VertexAttributeLayout::AttribIndex_t index) const {
 	assert(index < attributeLayout_.size());
 	VertexAttributeLayout::AttribSize_t sum{ 0 };
 	for ( int i{ 0 }; i < index; ++i ) {

--- a/src/resource/VBO.h
+++ b/src/resource/VBO.h
@@ -25,33 +25,25 @@ public:
 };
 
 
-
-
-class VBO : public IResource {
+class VBO : public VBOAllocator {
 private:
 	std::vector<float> data_;
 	std::vector<VertexAttributeLayout> attributeLayout_;
 
-	void acquireResource() noexcept { glGenBuffers(1, &id_); }
-	void releaseResource() noexcept { glDeleteBuffers(1, &id_); }
-
 public:
 	VBO(std::vector<float> data, std::vector<VertexAttributeLayout> attributeLayout)
-			: data_{ std::move(data) }, attributeLayout_{ std::move(attributeLayout) } {
-		acquireResource();
-	}
+			: data_{ std::move(data) }, attributeLayout_{ std::move(attributeLayout) } {}
 
-	virtual ~VBO() override { releaseResource(); }
+	// why did this not have a bind method before???
+	void bind() const { glBindBuffer(GL_ARRAY_BUFFER, id_); }
 
 	const std::vector<VertexAttributeLayout>& getLayout() const noexcept { return attributeLayout_; }
+
 	const std::vector<float>& getData() const noexcept { return data_; }
 
 	const VertexAttributeLayout::AttribSize_t getStride() const;
 
 	const VertexAttributeLayout::AttribSize_t getOffset(VertexAttributeLayout::AttribIndex_t index) const;
-
-	// why did this not have a bind method before???
-	void bind() const { glBindBuffer(GL_ARRAY_BUFFER, id_); }
 };
 
 

--- a/src/resource/VBO.h
+++ b/src/resource/VBO.h
@@ -16,6 +16,17 @@ struct VertexAttributeLayout {
 };
 
 
+class VBOAllocator : public IResource {
+protected:
+	VBOAllocator() noexcept { glGenBuffers(1, &id_); }
+
+public:
+	virtual ~VBOAllocator() override { glDeleteBuffers(1, &id_); }
+};
+
+
+
+
 class VBO : public IResource {
 private:
 	std::vector<float> data_;


### PR DESCRIPTION
Relevant TODO:
"could be interesting to try to separate the concerns of allocation by adding an intermediate Allocator class that implements noexcept acquire/release methods and noexcept constructors/destructors, so that whenever the derived class throws, deallocation happens automatically. For example, the inheritance would look like: IResource <- ShaderAllocator <- Shader."
