### PR TITLE
Implement context wrapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(world)
 add_subdirectory(resource)
 add_subdirectory(input)
 add_subdirectory(types)
+add_subdirectory(context)
 
 # internal dependencies
 target_link_libraries(ogllearn
@@ -13,6 +14,7 @@ target_link_libraries(ogllearn
         world
         input
         types
+        context
 )
 
 # external depenencies

--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(context INTERFACE)
+target_sources(context INTERFACE IContextWrapper.h)
+target_include_directories(context INTERFACE .)
+
+# external dependencies
+target_link_libraries(context
+    INTERFACE
+        glfw::glfw
+)

--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(context INTERFACE)
-target_sources(context INTERFACE IContextWrapper.h)
+target_sources(context INTERFACE IContextWrapper.h GLFWWindowWrapper.h)
 target_include_directories(context INTERFACE .)
 
 # external dependencies

--- a/src/context/GLFWWindowWrapper.h
+++ b/src/context/GLFWWindowWrapper.h
@@ -49,7 +49,7 @@ public:
 	void swapBuffers() { glfwSwapBuffers(window_); }
 
 	// implicit cast to window*
-	GLFWwindow* GLFWwindow() { return window_; }
+	operator GLFWwindow*() { return window_; }
 
 
 public:

--- a/src/context/GLFWWindowWrapper.h
+++ b/src/context/GLFWWindowWrapper.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <GLFW/glfw3.h>
+#include "IContextWrapper.h"
+
+class GLFWWindowWrapper : public IContextWrapper {
+
+
+public:
+	virtual ~GLFWWindowWrapper() override {
+		glfwTerminate();
+	}
+};

--- a/src/context/GLFWWindowWrapper.h
+++ b/src/context/GLFWWindowWrapper.h
@@ -1,8 +1,55 @@
 #pragma once
+#include <stdexcept>
 #include <GLFW/glfw3.h>
 #include "IContextWrapper.h"
 
+enum class GLFWOpenGLProfile {
+	any = GLFW_OPENGL_ANY_PROFILE,
+	core = GLFW_OPENGL_CORE_PROFILE,
+	compatibility = GLFW_OPENGL_COMPAT_PROFILE
+};
+
+struct WindowSize { int width; int height; };
+
 class GLFWWindowWrapper : public IContextWrapper {
+private:
+	GLFWwindow* window_;
+
+public:
+	GLFWWindowWrapper(int initWidth, int initHeight, const char* title,
+					  int contextVerMajor, int contextVerMinor,
+					  GLFWOpenGLProfile profile,
+					  GLFWmonitor* monitor = nullptr, GLFWwindow* share = nullptr) {
+		glfwInit();
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, contextVerMajor);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, contextVerMinor);
+		glfwWindowHint(GLFW_OPENGL_PROFILE, static_cast<int>(profile));
+
+		window_ = glfwCreateWindow(initWidth, initHeight, title, monitor, share);
+		if ( !window_ ) {
+			glfwTerminate();
+			throw std::runtime_error("runtime_error: failed to create GLFW window");
+		}
+
+		makeContextCurrent();
+	}
+
+	void makeContextCurrent() const { glfwMakeContextCurrent(window_); }
+
+	void setFramebufferSizeCallback(GLFWframebuffersizefun callback) {
+		glfwSetFramebufferSizeCallback(window_, callback);
+	}
+
+	WindowSize getWindowSize() {
+		int w, h;
+		glfwGetWindowSize(window_, &w, &h);
+		return { w, h };
+	}
+
+	void swapBuffers() { glfwSwapBuffers(window_); }
+
+	// implicit cast to window*
+	GLFWwindow* GLFWwindow() { return window_; }
 
 
 public:

--- a/src/context/IContextWrapper.h
+++ b/src/context/IContextWrapper.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/context/IContextWrapper.h
+++ b/src/context/IContextWrapper.h
@@ -1,1 +1,12 @@
 #pragma once
+#include <GLFW/glfw3.h>
+
+
+class IContextWrapper {
+public:
+	// provides abstract interface for RAII-enabled context creation
+	// also implicitly disables copy and move operations
+	virtual ~IContextWrapper() = 0;
+};
+
+inline IContextWrapper::~IContextWrapper() = default;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include "GLFWWindowWrapper.h"
 #include "TypeAliases.h"
 #include "Shader.h"
 #include "ShaderProgram.h"
@@ -30,53 +31,26 @@ float deltaFrameTime{};
 
 const OrthonormalBasis3D globalBasis{ glm::vec3(1.0f, 0.0, 0.0), glm::vec3(0.0f, 1.0f, 0.0f), true };
 
-std::tuple<int, int>  getWindowSize(GLFWwindow* window) {
-	int w, h;
-	glfwGetWindowSize(window, &w, &h);
-	return { w, h };
-}
-
 void framebufferSizeCallback(GLFWwindow* window, int width, int height) {
 	glViewport(0, 0, width, height);
 }
-
-[[nodiscard]] 
-GLFWwindow* initWindow(int width, int height, const std::string& name) {
-
-	glfwInit();
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-	GLFWwindow* window{ glfwCreateWindow(width, height, name.c_str(), nullptr, nullptr) };
-	if ( !window ) {
-		glfwTerminate();
-		throw std::runtime_error("runtime_error: failed to create GLFW window");
-	}
-
-	glfwMakeContextCurrent(window);
-
-	return window;
-}
-
 
 
 int main() {
 
 	// Init GLFW window
-	int defaultWidth{ 800 };
-	int defaultHeight{ 600 };
-	GLFWwindow* window{ initWindow(defaultWidth, defaultHeight, "Window Name") };
-
+	GLFWWindowWrapper window{ 800, 600, "Window Name", 3, 3, GLFWOpenGLProfile::core };
+	window.setFramebufferSizeCallback(framebufferSizeCallback);
 	glfwSwapInterval(0);
+
 	// Init GLAD
 	if ( !gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress)) ) {
 		throw std::runtime_error("runtime_error: failed to initialize GLAD");
 	}
-	glViewport(0, 0, defaultWidth, defaultHeight);
+	WindowSize windowSize { window.getWindowSize() };
+	glViewport(0, 0, windowSize.width, windowSize.height);
 
-	// Window size callback
-	glfwSetFramebufferSizeCallback(window, framebufferSizeCallback);
+
 
 
 
@@ -208,7 +182,7 @@ int main() {
 		glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		
-		auto [width, height] { getWindowSize(window) };
+		windowSize = window.getWindowSize();
 
 		input.processInput();
 
@@ -216,7 +190,7 @@ int main() {
 
 
 
-		projection = glm::perspective(cam.getFOV(), static_cast<float>(width) / static_cast<float>(height), 0.1f, 100.0f);
+		projection = glm::perspective(cam.getFOV(), static_cast<float>(windowSize.width) / static_cast<float>(windowSize.height), 0.1f, 100.0f);
 		view = cam.getViewMat();
 
 		// Lighting Source
@@ -295,7 +269,7 @@ int main() {
 
 
 
-		glfwSwapBuffers(window);
+		window.swapBuffers();
 		glfwPollEvents();
 	}
 
@@ -312,7 +286,7 @@ int main() {
 
 
 
-	glfwTerminate();
+
 
 	return 0;
 }


### PR DESCRIPTION
Adds `GLFWWindowWrapper` class that encapsulates `GLFWwindow*`, provides basic initialization on construction and terminates glfw on destruction. 

Technically, `glfwInit()` and `glfwTerminate()` are not related to any particular window instance, but for the intents of a single window per process application, this will do.

Closes #7 