### PR TITLE
Tutorial Lighting/Light casters & Lighting/Multiple lights

### DIFF
--- a/resources/shaders/MultiLightObject.frag
+++ b/resources/shaders/MultiLightObject.frag
@@ -1,0 +1,150 @@
+#version 330 core
+
+in vec3 normal;
+in vec3 fragPos;
+in vec2 texCoord;
+
+uniform vec3 camPos;
+
+struct Material {
+    sampler2D diffuse;      // color reflected under diffuse lighting
+    sampler2D specular;     // color of the specular highlight
+    float shininess;        // defines the scattering radius of the highlight
+};
+
+uniform Material material;
+
+// Light sources
+struct Attenuation {
+    float constant;
+    float linear;
+    float quadratic;
+};
+
+struct DirectionalLight {
+    vec3 color;
+    vec3 direction;
+};
+
+struct PointLight {
+    vec3 color;
+    vec3 position;
+    Attenuation attenuation;
+};
+
+struct SpotlightLight {
+    vec3 color;
+    vec3 position;
+    vec3 direction;
+    Attenuation attenuation;
+    float innerCutoffCos;
+    float outerCutoffCos;
+};
+
+uniform DirectionalLight dirLight;
+#define NUM_POINT_LIGHTS 4
+uniform PointLight pointLights[NUM_POINT_LIGHTS];
+uniform SpotlightLight spotLight;
+
+out vec4 fragColor;
+
+
+struct TextureColor {
+    vec3 diffuse;
+    vec3 specular;
+};
+
+struct LightParams {
+    float ambientStrength;
+    float diffuseStrength;
+    float specularStrength;
+    float specularAlignment;
+    float distanceFactor;
+};
+
+LightParams getLightParams(vec3 normalDir, vec3 lightDir, vec3 viewDir, float lightDistance, Attenuation att);
+vec3 getTotalLightColor(vec3 lightColor, const LightParams lp, TextureColor texColor);
+
+
+vec3 getLightDirectional(DirectionalLight light, vec3 normalDir, vec3 viewDir, TextureColor texColor) {
+
+    vec3 lightDir = normalize(-light.direction); // direction from fragment to light ???
+    Attenuation noAtt = {1.0f, 0.0f, 0.0f}; // no distance scaling for directional light
+    LightParams lp = getLightParams(normalDir, lightDir, viewDir, 0.0f, noAtt);
+
+    return getTotalLightColor(light.color, lp, texColor);
+}
+
+vec3 getLightPoint(PointLight light, vec3 normalDir, vec3 viewDir, TextureColor texColor) {
+
+    vec3 lightVec = light.position - fragPos; // vector from light source to fragment
+    vec3 lightDir = normalize(lightVec); // direction from fragment to light
+    float lightDistance = length(lightVec);
+    LightParams lp = getLightParams(normalDir, lightDir, viewDir, lightDistance, light.attenuation);
+
+    return getTotalLightColor(light.color, lp, texColor);
+}
+
+vec3 getLightSpotlight(SpotlightLight light, vec3 normalDir, vec3 viewDir, TextureColor texColor) {
+    vec3 lightVec = light.position - fragPos; // vector from light source to fragment
+    vec3 lightDir = normalize(lightVec); // direction from fragment to light (NOT direction of source)
+    float thetaCos = dot(lightDir, normalize(-light.direction)); // cos(angle) between light.direction and light-to-fragment dir
+
+    vec3 result;
+    if (thetaCos > light.outerCutoffCos) {
+        float lightDistance = length(lightVec);
+        LightParams lp = getLightParams(normalDir, lightDir, viewDir, lightDistance, light.attenuation);
+        result = getTotalLightColor(light.color, lp, texColor);
+    }
+    else {
+        result = vec3(0.0f); // no light ouside the cutoff
+    }
+
+    return result;
+}
+
+
+
+
+void main() {
+
+    // -- Geometry --
+    // normal unit vector of fragment
+    vec3 normalDir = normalize(normal);
+    // direction from fragment to camera
+    vec3 viewDir = normalize(camPos - fragPos);
+    TextureColor texColor;
+    texColor.diffuse = vec3(texture(material.diffuse, texCoord));
+    texColor.specular = vec3(texture(material.specular, texCoord));
+
+    vec3 result = getLightDirectional(dirLight, normalDir, viewDir, texColor);
+
+    for (int i = 0; i < NUM_POINT_LIGHTS; ++i) {
+        result += getLightPoint(pointLights[i], normalDir, viewDir, texColor);
+    }
+
+    result += getLightSpotlight(spotLight, normalDir, viewDir, texColor);
+
+    fragColor = vec4(result, 1.0f);
+}
+
+LightParams getLightParams(vec3 normalDir, vec3 lightDir, vec3 viewDir, float lightDistance, Attenuation att) {
+    LightParams lp;
+    lp.diffuseStrength = max(dot(normalDir, lightDir), 0.0f);
+    lp.ambientStrength = 0.1f;
+    lp.specularStrength = 0.8f;
+    vec3 reflectionDir = reflect(-lightDir, normalDir); // reflection direction around a normal
+    lp.specularAlignment = max(dot(viewDir, reflectionDir), 0.0f);   // how close camera is to the reflection line
+    lp.distanceFactor = 1.0f / (att.constant + att.linear * lightDistance + att.quadratic * (lightDistance * lightDistance));
+    return lp;
+}
+
+vec3 getTotalLightColor(vec3 lightColor, const LightParams lp, TextureColor texColor) {
+    // Colors
+    vec3 ambientColor = lp.ambientStrength * texColor.diffuse;
+    vec3 diffuseColor = lp.diffuseStrength * texColor.diffuse * lightColor;
+    vec3 specularColor = lp.specularStrength * texColor.specular * pow(lp.specularAlignment, material.shininess) * lightColor;
+
+    return (ambientColor + lp.distanceFactor * (diffuseColor + specularColor));
+}
+

--- a/resources/shaders/MultiLightObject.frag
+++ b/resources/shaders/MultiLightObject.frag
@@ -69,7 +69,7 @@ vec3 getTotalLightColor(vec3 lightColor, const LightParams lp, TextureColor texC
 vec3 getLightDirectional(DirectionalLight light, vec3 normalDir, vec3 viewDir, TextureColor texColor) {
 
     vec3 lightDir = normalize(-light.direction); // direction from fragment to light ???
-    Attenuation noAtt = {1.0f, 0.0f, 0.0f}; // no distance scaling for directional light
+    Attenuation noAtt = Attenuation(1.0f, 0.0f, 0.0f); // no distance scaling for directional light
     LightParams lp = getLightParams(normalDir, lightDir, viewDir, 0.0f, noAtt);
 
     return getTotalLightColor(light.color, lp, texColor);

--- a/resources/shaders/MultiLightObject.frag
+++ b/resources/shaders/MultiLightObject.frag
@@ -154,6 +154,6 @@ vec3 getTotalLightColor(vec3 lightColor, const LightParams lp, TextureColor texC
     vec3 diffuseColor = lp.diffuseStrength * texColor.diffuse * lightColor;
     vec3 specularColor = lp.specularStrength * texColor.specular * pow(lp.specularAlignment, material.shininess) * lightColor;
     // FIXME: the ambient color from all sources stacks unconditionally
-    return (ambientColor + lp.distanceFactor * (diffuseColor + specularColor));
+    return (lp.distanceFactor * (ambientColor + diffuseColor + specularColor));
 }
 

--- a/resources/shaders/MultiLightObject.frag
+++ b/resources/shaders/MultiLightObject.frag
@@ -92,9 +92,18 @@ vec3 getLightSpotlight(SpotlightLight light, vec3 normalDir, vec3 viewDir, Textu
 
     vec3 result;
     if (thetaCos > light.outerCutoffCos) {
+        float edgeFactor;
+        if (thetaCos < light.innerCutoffCos) {
+            edgeFactor = clamp(
+                (thetaCos - light.outerCutoffCos) / (light.innerCutoffCos - light.outerCutoffCos),
+                0.0f, 1.0f
+            );
+        }
+        else { edgeFactor = 1.0f; }
+
         float lightDistance = length(lightVec);
         LightParams lp = getLightParams(normalDir, lightDir, viewDir, lightDistance, light.attenuation);
-        result = getTotalLightColor(light.color, lp, texColor);
+        result = edgeFactor * getTotalLightColor(light.color, lp, texColor);
     }
     else {
         result = vec3(0.0f); // no light ouside the cutoff
@@ -144,7 +153,7 @@ vec3 getTotalLightColor(vec3 lightColor, const LightParams lp, TextureColor texC
     vec3 ambientColor = lp.ambientStrength * texColor.diffuse;
     vec3 diffuseColor = lp.diffuseStrength * texColor.diffuse * lightColor;
     vec3 specularColor = lp.specularStrength * texColor.specular * pow(lp.specularAlignment, material.shininess) * lightColor;
-
+    // FIXME: the ambient color from all sources stacks unconditionally
     return (ambientColor + lp.distanceFactor * (diffuseColor + specularColor));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "Input.h"
 #include "VBO.h"
 #include "VAO.h"
+#include "LightCasters.h"
 
 float currentFrameTime{};
 float lastFrameTime{};
@@ -136,6 +137,14 @@ int main() {
 			glm::vec3(-1.3f,  1.0f, -1.5f)
 	};
 
+	std::vector<glm::vec3> pointLightPositions {
+			glm::vec3( 0.7f,  0.2f,  2.0f),
+			glm::vec3( 2.3f, -3.3f, -4.0f),
+			glm::vec3(-4.0f,  2.0f, -12.0f),
+			glm::vec3( 0.0f,  0.0f, -3.0f)
+	};
+
+
 	// Creating camera and binding it to input
 	Camera cam{ glm::vec3(0.0f, 0.0f, 3.0f), glm::vec3(0.0f, 0.0f, -1.0f) };
 	InputFreeCamera input{ window, cam };
@@ -164,30 +173,10 @@ int main() {
 		projection = glm::perspective(cam.getFOV(), static_cast<float>(windowSize.width) / static_cast<float>(windowSize.height), 0.1f, 100.0f);
 		view = cam.getViewMat();
 
-		// Lighting Source
-		SPLightSource.use();
-
-		glm::vec3 lightColor{ 1.0f };
-//		glm::vec3 lightColor{
-//				(1.0f + glm::vec3{glm::sin(0.5f * currentFrameTime), glm::sin(currentFrameTime), glm::sin(2.0f * currentFrameTime)}) / 2.0f
-//		};
-//		//glm::vec3 lightPos{ glm::sin(currentFrameTime), 3.0f, 2.0f * glm::cos(currentFrameTime) };
-		glm::vec3 lightPos{ -2.0f, -0.5f, 1.5f };
 		glm::vec3 camPos{ cam.getPos() };
 
-		model = glm::mat4{ 1.0f };
-		model = glm::translate(model, lightPos);
-		model = glm::scale(model, glm::vec3{ 0.2f });
-		normalModel = glm::mat3(glm::transpose(glm::inverse(model)));
-		SPLightSource.setUniform("model", model);
-		SPLightSource.setUniform("normalModel", normalModel);
-		SPLightSource.setUniform("projection", projection);
-		SPLightSource.setUniform("view", view);
-		SPLightSource.setUniform("lightColor", lightColor);
 
-		lightVAO.bindAndDraw();
-
-		// Textured diff+spec object
+		// Textured diff+spec objects with multiple of lights shining on them
 		SPMultiLight.use();
 
 		boxVAO.bind();
@@ -196,9 +185,71 @@ int main() {
 		SPMultiLight.setUniform("view", view);
 		SPMultiLight.setUniform("camPos", camPos);
 
-		SPMultiLight.setUniform("lightColor", lightColor);
-		SPMultiLight.setUniform("lightPos", lightPos);
+		// ---- Light Sources ----
+		// (most of them are constant, but I'll set them within the render loop anyway, for clarity)
 
+		// Directional
+		light::Directional ld{
+			.color = { 0.3f, 0.3f, 0.2f },
+			.direction = { -0.2f, -1.0f, -0.3f }
+		};
+		SPMultiLight.setUniform("dirLight.color", ld.color);
+		SPMultiLight.setUniform("dirLight.direction", ld.direction);
+
+
+		// Point
+		std::vector<light::Point> lps;
+		lps.reserve(4);
+		for (int i{ 0 }; i < 4; ++i) {
+			lps.emplace_back(light::Point{
+					.color = glm::vec3(1.0f, 0.0f, 1.0f),
+					.position = pointLightPositions[i],
+					.attenuation = light::Attenuation{ .constant = 1.0f, .linear = 0.4f, .quadratic = 0.2f },
+			});
+		}
+
+		for (int i{ 0 }; i < 4; ++i) {
+			// what a mess, though
+			std::string colName{ "pointLights[x].color" };
+			std::string posName{ "pointLights[x].position" };
+			std::string att0Name{ "pointLights[x].attenuation.constant" };
+			std::string att1Name{ "pointLights[x].attenuation.linear" };
+			std::string att2Name{ "pointLights[x].attenuation.quadratic" };
+			auto iString {std::to_string(i)};
+			colName.replace(12, 1, iString);
+			posName.replace(12, 1, iString);
+			att0Name.replace(12, 1, iString);
+			att1Name.replace(12, 1, iString);
+			att2Name.replace(12, 1, iString);
+
+			SPMultiLight.setUniform(colName.c_str(), lps[i].color);
+			SPMultiLight.setUniform(posName.c_str(), lps[i].position);
+			SPMultiLight.setUniform(att0Name.c_str(), lps[i].attenuation.constant);
+			SPMultiLight.setUniform(att1Name.c_str(), lps[i].attenuation.linear);
+			SPMultiLight.setUniform(att2Name.c_str(), lps[i].attenuation.quadratic);
+		}
+
+
+		// Spotlight
+		light::Spotlight ls{
+				.color = glm::vec3(1.0f),
+				.position = camPos,
+				.direction = -cam.backUV(),
+				.attenuation = light::Attenuation{ .constant = 1.0f, .linear = 1.0f, .quadratic = 2.1f },
+				.innerCutoffRad = glm::radians(12.0f),
+				.outerCutoffRad = glm::radians(15.0f)
+		};
+		SPMultiLight.setUniform("spotLight.color", ls.color);
+		SPMultiLight.setUniform("spotLight.position", ls.position);
+		SPMultiLight.setUniform("spotLight.direction", ls.direction);
+		SPMultiLight.setUniform("spotLight.attenuation.constant", ls.attenuation.constant);
+		SPMultiLight.setUniform("spotLight.attenuation.linear", ls.attenuation.linear);
+		SPMultiLight.setUniform("spotLight.attenuation.quadratic", ls.attenuation.quadratic);
+		SPMultiLight.setUniform("spotLight.innerCutoffCos", glm::cos(ls.innerCutoffRad));
+		SPMultiLight.setUniform("spotLight.outerCutoffCos", glm::cos(ls.outerCutoffRad));
+
+
+		// ---- Scene of Boxes ----
 
 		for (size_t i{0}; i < 10; ++i) {
 			model = glm::mat4{ 1.0f };
@@ -217,27 +268,30 @@ int main() {
 
 
 
-//		normalModel = glm::mat3(glm::transpose(glm::inverse(model)));
+		// Point Lighting Sources
 
-//		SPMultiLight.setUniform("model", model);
-//		SPMultiLight.setUniform("normalModel", normalModel);
-//		SPMultiLight.setUniform("projection", projection);
-//		SPMultiLight.setUniform("view", view);
+		SPLightSource.use();
 
-//		SPMultiLight.setUniform("lightColor", lightColor);
-//		SPMultiLight.setUniform("lightPos", lightPos);
-		//SPMultiLight.setUniform("camPos", camPos);
+		lightVAO.bind();
 
 
-//		boxTexDiffuse.setActiveUnitAndBind(2);
-//		boxTexSpecular.setActiveUnitAndBind(3);
-
-//		SPMultiLight.setUniform("material.diffuse", static_cast<GLenum>(0));
-//		SPMultiLight.setUniform("material.specular", static_cast<GLenum>(1));
-//		SPMultiLight.setUniform("material.shininess", 128.0f);
+		SPLightSource.setUniform("projection", projection);
+		SPLightSource.setUniform("view", view);
 
 
-//		boxVAO.bindAndDraw();
+		for (size_t i{0}; i < 4; ++i) {
+			model = glm::mat4{ 1.0f };
+			model = glm::translate(model, pointLightPositions[i]);
+			model = glm::scale(model, glm::vec3{ 0.2f });
+			SPLightSource.setUniform("model", model);
+
+			normalModel = glm::mat3(glm::transpose(glm::inverse(model)));
+			SPLightSource.setUniform("normalModel", normalModel);
+
+			SPLightSource.setUniform("lightColor", lps[i].color);
+
+			lightVAO.draw();
+		}
 
 
 	}

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(types INTERFACE)
-target_sources(types INTERFACE TypeAliases.h)
+target_sources(types INTERFACE TypeAliases.h LightCasters.h)
 target_include_directories(types INTERFACE .)

--- a/src/types/LightCasters.h
+++ b/src/types/LightCasters.h
@@ -3,10 +3,6 @@
 
 namespace light {
 
-	struct Colored {
-		glm::vec3 color;
-	};
-
 	struct Attenuation {
 		float constant;
 		float linear;
@@ -14,16 +10,19 @@ namespace light {
 	};
 
 
-	struct Directional : Colored {
+	struct Directional {
+		glm::vec3 color;
 		glm::vec3 direction;
 	};
 
-	struct Point : Colored {
+	struct Point {
+		glm::vec3 color;
 		glm::vec3 position;
 		Attenuation attenuation;
 	};
 
-	struct Spotlight : Colored {
+	struct Spotlight {
+		glm::vec3 color;
 		glm::vec3 position;
 		glm::vec3 direction;
 		Attenuation attenuation;

--- a/src/types/LightCasters.h
+++ b/src/types/LightCasters.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <glm/glm.hpp>
+
+namespace light {
+
+	struct Colored {
+		glm::vec3 color;
+	};
+
+	struct Attenuation {
+		float constant;
+		float linear;
+		float quadratic;
+	};
+
+
+	struct Directional : Colored {
+		glm::vec3 direction;
+	};
+
+	struct Point : Colored {
+		glm::vec3 position;
+		Attenuation attenuation;
+	};
+
+	struct Spotlight : Colored {
+		glm::vec3 position;
+		glm::vec3 direction;
+		Attenuation attenuation;
+		float innerCutoffRad;
+		float outerCutoffRad;
+	};
+
+}


### PR DESCRIPTION
Did the steps. This concludes all the chapters of Lighting section.

Restores a scene with 10 boxes, adds a directional light source, 4 point lights and a flashlight to the scene. Adds `LightCasters` types that describe light source properties. Introduces new fragment shader that supports all of these sources. 